### PR TITLE
fix: reset regex state in hasEditProposals

### DIFF
--- a/__tests__/edit-parser.test.ts
+++ b/__tests__/edit-parser.test.ts
@@ -84,4 +84,11 @@ describe('hasEditProposals', () => {
   it('returns false for plain text', () => {
     expect(hasEditProposals('no code here')).toBe(false)
   })
+
+  it('returns consistent results on consecutive calls', () => {
+    const text = '[EDIT foo.ts]\n```\ncode\n```'
+    expect(hasEditProposals(text)).toBe(true)
+    expect(hasEditProposals(text)).toBe(true)
+    expect(hasEditProposals(text)).toBe(true)
+  })
 })

--- a/lib/edit-parser.ts
+++ b/lib/edit-parser.ts
@@ -73,5 +73,7 @@ export function parseEditProposals(text: string): EditProposal[] {
 }
 
 export function hasEditProposals(text: string): boolean {
+  EDIT_MARKER_RE.lastIndex = 0
+  FENCED_WITH_PATH_RE.lastIndex = 0
   return EDIT_MARKER_RE.test(text) || FENCED_WITH_PATH_RE.test(text)
 }


### PR DESCRIPTION
## Type

- [x] `fix` — bug fix

## What

Resets `lastIndex` to 0 on both module-level regexes before calling `.test()` in `hasEditProposals`. Adds a regression test that calls the function three times consecutively with the same input.

## Why

Both `EDIT_MARKER_RE` and `FENCED_WITH_PATH_RE` are declared with the `/g` flag (required by `matchAll` in `parseEditProposals`). `RegExp.prototype.test()` on a global regex advances `lastIndex` after a match, so consecutive calls to `hasEditProposals` with the same input alternate between `true` and `false`. This causes the editor to silently drop edit proposals on every other streaming update.

## Testing

- [x] `pnpm check` passes
- [x] `pnpm test` passes (80/80, including new regression test)
- [x] New test: `returns consistent results on consecutive calls` — fails on `main`, passes with fix

cc @BunsDev